### PR TITLE
PXY-1661 Upgrade square-wireschema from 4.3.0 to 5.0.0

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.21
 * Upgraded Avro dependencies version to fix vulnerabilities
+
+## Release 1.1.22
+* Upgraded protobuf dependencies version to fix vulnerabilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.20
 * Upgrade the dependency version to remove commons:compress dependency
+
+## Release 1.1.21
+* Upgraded Avro dependencies version to fix vulnerabilities

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
   <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.20</version>
+      <version>1.1.21</version>
   </dependency>
   ```
 ### Code Example
@@ -490,7 +490,7 @@ It should look like this
 * If using bash, run the below commands to set-up your CLASSPATH in your bash_profile. (For any other shell, update the environment accordingly.)
   ```bash
       echo 'export GSR_LIB_BASE_DIR=<>' >>~/.bash_profile
-      echo 'export GSR_LIB_VERSION=1.1.20' >>~/.bash_profile
+      echo 'export GSR_LIB_VERSION=1.1.21' >>~/.bash_profile
       echo 'export KAFKA_HOME=<your kafka installation directory>' >>~/.bash_profile
       echo 'export CLASSPATH=$CLASSPATH:$GSR_LIB_BASE_DIR/avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/common/target/schema-registry-common-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/avro-serializer-deserializer/target/schema-registry-serde-$GSR_LIB_VERSION.jar' >>~/.bash_profile
       source ~/.bash_profile
@@ -549,7 +549,7 @@ It should look like this
   <dependency>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-kafkastreams-serde</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
   </dependency>
   ```
 
@@ -587,7 +587,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.20</version>
+       <version>1.1.21</version>
   </dependency>
   ```
 ### Code Example

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
   <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.21</version>
+      <version>1.1.22</version>
   </dependency>
   ```
 ### Code Example
@@ -490,7 +490,7 @@ It should look like this
 * If using bash, run the below commands to set-up your CLASSPATH in your bash_profile. (For any other shell, update the environment accordingly.)
   ```bash
       echo 'export GSR_LIB_BASE_DIR=<>' >>~/.bash_profile
-      echo 'export GSR_LIB_VERSION=1.1.21' >>~/.bash_profile
+      echo 'export GSR_LIB_VERSION=1.1.22' >>~/.bash_profile
       echo 'export KAFKA_HOME=<your kafka installation directory>' >>~/.bash_profile
       echo 'export CLASSPATH=$CLASSPATH:$GSR_LIB_BASE_DIR/avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/common/target/schema-registry-common-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/avro-serializer-deserializer/target/schema-registry-serde-$GSR_LIB_VERSION.jar' >>~/.bash_profile
       source ~/.bash_profile
@@ -549,7 +549,7 @@ It should look like this
   <dependency>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-kafkastreams-serde</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
   </dependency>
   ```
 
@@ -587,7 +587,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.21</version>
+       <version>1.1.22</version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/README.md
+++ b/avro-flink-serde/README.md
@@ -20,7 +20,7 @@ inside Amazon VPC.](https://docs.aws.amazon.com/kinesisanalytics/latest/java/vpc
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.21/version>
+       <version>1.1.22/version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/README.md
+++ b/avro-flink-serde/README.md
@@ -20,7 +20,7 @@ inside Amazon VPC.](https://docs.aws.amazon.com/kinesisanalytics/latest/java/vpc
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.20/version>
+       <version>1.1.21/version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.21</version>
+    <version>1.1.22</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.21</version>
+            <version>1.1.22</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.20</version>
+    <version>1.1.21</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.20</version>
+            <version>1.1.21</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -66,10 +66,10 @@
             <version>1.1.22</version>
         </dependency>
         <dependency>
-          <groupId>org.projectlombok</groupId>
-          <artifactId>lombok</artifactId>
-          <version>1.18.26</version>
-          <scope>provided</scope>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.26</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -202,7 +202,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                <source>8</source>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-	<protobuf.version>3.19.6</protobuf.version>
+	<protobuf.version>3.25.5</protobuf.version>
 	<kotlin.version>1.7.10</kotlin.version>
         <square-wireschema.version>4.3.0</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
@@ -112,7 +112,7 @@
         <commons.lang3.version>3.8.1</commons.lang3.version>
         <commons.cli.version>1.2</commons.cli.version>
         <awaitility.version>3.0.0</awaitility.version>
-        <protobuf.java.version>3.19.6</protobuf.java.version>
+        <protobuf.java.version>3.25.5</protobuf.java.version>
         <localstack.utils>0.2.23</localstack.utils>
         <aws.msk.iam.auth>2.0.3</aws.msk.iam.auth>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <aws.sdk.v1.version>1.12.660</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <kafka.version>3.6.1</kafka.version>
-        <avro.version>1.11.3</avro.version>
+        <avro.version>1.11.4</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
         <everit.json.schema.version>1.14.2</everit.json.schema.version>
         <classgraph.version>4.8.120</classgraph.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.20</version>
+    <version>1.1.21</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.21</version>
+    <version>1.1.22</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their

--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-	<protobuf.version>3.25.5</protobuf.version>
-	<kotlin.version>1.7.10</kotlin.version>
-        <square-wireschema.version>4.3.0</square-wireschema.version>
+        <protobuf.version>3.25.5</protobuf.version>
+        <kotlin.version>2.0.21</kotlin.version>
+        <square-wireschema.version>5.0.0</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
@@ -165,11 +165,11 @@
                 <artifactId>avro</artifactId>
                 <version>${avro.version}</version>
                 <exclusions>
-                  <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                  </exclusion>
-               </exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-compress</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Exclude commons-compress globally due to vulns -->
             <dependency>
@@ -288,8 +288,8 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                    <groupId>software.amazon.ion</groupId>
-                    <artifactId>ion-java</artifactId>
+                        <groupId>software.amazon.ion</groupId>
+                        <artifactId>ion-java</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.21</version>
+        <version>1.1.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.20</version>
+        <version>1.1.21</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
@@ -584,7 +584,7 @@ public class FileDescriptorUtils {
      * This method generates the synthetic one-of from a Proto3 optional field.
      */
     private static OneOf getProto3OptionalField(Field field) {
-        return new OneOf("_" + field.getName(), "", Collections.singletonList(field));
+        return new OneOf("_" + field.getName(), "", Collections.singletonList(field), field.getLocation(), field.getOptions());
     }
 
     private static EnumDescriptorProto enumElementToProto(EnumType enumElem) {
@@ -852,7 +852,7 @@ public class FileDescriptorUtils {
             int start = extensionRange.getStart();
             int end = extensionRange.getEnd() - 1;
             values.add(new IntRange(start, end));
-            ExtensionsElement extensionsElement = new ExtensionsElement(DEFAULT_LOCATION, "", values);
+            ExtensionsElement extensionsElement = new ExtensionsElement(DEFAULT_LOCATION, "", values, Collections.emptyList());
             extensions.add(extensionsElement);
         }
         ImmutableList.Builder<OptionElement> options = ImmutableList.builder();
@@ -878,12 +878,13 @@ public class FileDescriptorUtils {
                     .filter(e -> e.getValue().build().size() != 0)
                     .map(e -> toOneof(e.getKey(), e.getValue())).collect(Collectors.toList()),
                 extensions.build(),
+                Collections.emptyList(),
                 Collections.emptyList()
         );
     }
 
     private static OneOfElement toOneof(String name, ImmutableList.Builder<FieldElement> fields) {
-        return new OneOfElement(name, "", fields.build(), Collections.emptyList(), Collections.emptyList());
+        return new OneOfElement(name, "", fields.build(), Collections.emptyList(), Collections.emptyList(), DEFAULT_LOCATION);
     }
 
     private static EnumElement toEnum(EnumDescriptorProto ed) {

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static com.google.protobuf.DescriptorProtos.*;
+import static com.squareup.wire.schema.Options.ONEOF_OPTIONS;
 
 /**
  * @author Fabian Martinez, Ravindranath Kakarla, Carles Arnal
@@ -584,7 +585,7 @@ public class FileDescriptorUtils {
      * This method generates the synthetic one-of from a Proto3 optional field.
      */
     private static OneOf getProto3OptionalField(Field field) {
-        return new OneOf("_" + field.getName(), "", Collections.singletonList(field), field.getLocation(), field.getOptions());
+        return new OneOf("_" + field.getName(), "", Collections.singletonList(field), DEFAULT_LOCATION, new Options(ONEOF_OPTIONS, Collections.emptyList()));
     }
 
     private static EnumDescriptorProto enumElementToProto(EnumType enumElem) {


### PR DESCRIPTION
### What does this PR do:
While supporting AWS Glue Schema Registry for Gateway encryption, there is a conflict between Confluent and AWS Glue Schema Registry.

Confluent Schema Registry requires square-wireschema version 5.0.0, while AWS Glue Schema Registry (this repository) only uses version 4.3.0.

This PR upgrades the square-wireschema library from version 4.3.0 to 5.0.0.